### PR TITLE
fix: align with SDK v0.10.0

### DIFF
--- a/worker.ts
+++ b/worker.ts
@@ -8,7 +8,7 @@ const resonate = new Resonate({
 
 function* sleepingWorkflow(ctx: Context, ms: number) {
   yield* ctx.run((ctx: Context) => console.log(`Sleeping for ${ms / 1000} seconds...`))
-  yield ctx.sleep(ms);
+  yield* ctx.sleep(ms);
   return `Slept for ${ms / 1000} seconds`;
 }
 


### PR DESCRIPTION
## Summary
- Fixed bare `yield ctx.sleep(ms)` to `yield* ctx.sleep(ms)` in `worker.ts` (line 11)
- This was a **runtime bug** — without `yield*`, the durable sleep will not properly suspend and resume

## Context
Part of the Resonate v0.10.0 alignment sweep (iteration-06).

## Test plan
- [x] `npm install` succeeds
- [x] `npx tsc --noEmit` passes
- [ ] Code review confirms fix is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)